### PR TITLE
Depend satysfi-dist

### DIFF
--- a/Satyristes
+++ b/Satyristes
@@ -22,5 +22,6 @@
     ((doc "manual.pdf" "doc/manual.pdf")))
   (opam "satysfi-class-shinchoku-tairiku-doc.opam")
   (dependencies
-    ((class-shinchoku-tairiku ())
+    ((dist ())
+     (class-shinchoku-tairiku ())
     )))

--- a/doc/author1/main.satyh
+++ b/doc/author1/main.satyh
@@ -1,3 +1,4 @@
+@require: pervasives
 @require: class-shinchoku-tairiku/shinchoku-tairiku
 
 let bib-items = [

--- a/satysfi-class-shinchoku-tairiku-doc.opam
+++ b/satysfi-class-shinchoku-tairiku-doc.opam
@@ -15,6 +15,7 @@ depends: [
   "satysfi" { >= "0.0.5" & < "0.0.6" }
   "satyrographos" { >= "0.0.2.6" & < "0.0.3" }
 
+  "satysfi-dist"
   "satysfi-class-shinchoku-tairiku" {= "%{version}%"}
 ]
 build: [


### PR DESCRIPTION
`manual` の中で標準ライブラリにある `\SATySFi` コマンドを使っていたのに依存ライブラリに標準ライブラリを指定していませんでした。
https://github.com/gfngfn/SATySFi/blob/master/lib-satysfi/dist/packages/pervasives.satyh